### PR TITLE
Ensure that a fake compilation database is generated for headers on targets.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,8 @@ add_cmake_build_test (ClangTidyAllowWarningsOption
                       ClangTidyAllowWarningsOptionVerify)
 add_cmake_build_test (ClangTidyGenerateSpecialCompilationDB
                       ClangTidyGenerateSpecialCompilationDBVerify)
+add_cmake_build_test (ClangTidyGenerateSpecialCompilationDBForRealTargetHeaders
+                      ClangTidyGenerateSpecialCompilationDBForRealTargetHeadersVerify)
 add_cmake_build_test (ClangTidySpecialCompilationDBIncludes
                       ClangTidySpecialCompilationDBIncludesVerify)
 add_cmake_build_test (ClangTidySpecialCompilationDBDefines

--- a/test/ClangTidyGenerateSpecialCompilationDBForRealTargetHeaders.cmake
+++ b/test/ClangTidyGenerateSpecialCompilationDBForRealTargetHeaders.cmake
@@ -1,0 +1,42 @@
+# /tests/ClangTidyGenerateSpecialCompilationDBForRealTargetHeaders.cmake
+# Add some sources to a compilable target and run clang-tidy on them.
+# Headers (which are not compiled) will be added to the target's sources.
+# We should put those headers in a separate compilation database so that
+# can still check them.
+#
+# See LICENCE.md for Copyright information
+
+include (${CLANG_TIDY_CMAKE_TESTS_DIRECTORY}/CMakeUnit.cmake)
+include (${CLANG_TIDY_CMAKE_DIRECTORY}/ClangTidy.cmake)
+
+_validate_clang_tidy (CONTINUE)
+
+set (HEADER_FILE ${CMAKE_CURRENT_BINARY_DIR}/Header.h)
+set (CPP_SOURCE_FILE ${CMAKE_CURRENT_BINARY_DIR}/Source.cpp)
+set (HEADER_FILE_CONTENTS
+     "#ifndef HEADER_H\n"
+     "#define HEADER_H\n"
+     "extern const int i\;\n"
+     "#endif")
+set (CPP_SOURCE_FILE_CONTENTS
+     "#include <Header.h>\n"
+     "const int i = 1\;\n"
+     "int main (void)\n"
+     "{\n"
+     "    return 0\;\n"
+     "}\n")
+set (TARGET executable)
+
+file (WRITE ${HEADER_FILE} ${HEADER_FILE_CONTENTS})
+file (WRITE ${CPP_SOURCE_FILE} ${CPP_SOURCE_FILE_CONTENTS})
+
+include_directories (${CMAKE_CURRENT_BINARY_DIR})
+
+add_executable (${TARGET}
+                ${CPP_SOURCE_FILE}
+                ${HEADER_FILE})
+clang_tidy_check_target_sources (${TARGET}
+                                 INTERNAL_INCLUDE_DIRS
+                                 ${CMAKE_CURRENT_BINARY_DIR}
+                                 DISABLE_CHECKS
+                                 llvm-*)

--- a/test/ClangTidyGenerateSpecialCompilationDBForRealTargetHeadersVerify.cmake
+++ b/test/ClangTidyGenerateSpecialCompilationDBForRealTargetHeadersVerify.cmake
@@ -1,0 +1,28 @@
+# /tests/ClangTidyGenerateSpecialCompilationDBForRealTargetHeadersVerify.cmake
+# Check that clang-tidy was run on our Header with its own compilation DB.
+# The source should be found in the main compilation DB and the header is
+# to be found in
+# ${CMAKE_CURRENT_BINARY_DIR}/executable_compile_commands/compile_commands.json
+#
+# See LICENCE.md for Copyright information
+
+include (${CLANG_TIDY_CMAKE_TESTS_DIRECTORY}/CMakeUnit.cmake)
+set (BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/BUILD.output)
+
+set (SOURCE_COMMAND
+     "^.*clang-tidy.*Source.cpp.*$")
+assert_file_has_line_matching (${BUILD_OUTPUT} ${SOURCE_COMMAND})
+
+set (HEADER_COMMAND
+     "^.*clang-tidy.*-p.*executable_compile_commands.*Header.h.*$")
+assert_file_has_line_matching (${BUILD_OUTPUT} ${HEADER_COMMAND})
+
+set (MAIN_COMPILE_COMMANDS
+     ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
+assert_file_has_line_matching (${MAIN_COMPILE_COMMANDS}
+                               "^.*${CMAKE_CURRENT_BINARY_DIR}/Source.cpp.*$")
+
+set (AUX_COMPILE_COMMANDS
+     ${CMAKE_CURRENT_BINARY_DIR}/executable_compile_commands/compile_commands.json)
+assert_file_has_line_matching (${AUX_COMPILE_COMMANDS}
+                               "^.*${CMAKE_CURRENT_BINARY_DIR}/Header.h.*$")


### PR DESCRIPTION
Header files specified on a target won't be added to compile_commands.json
but we might want to run clang-tidy on them. Add them to
${TARGET}_compile_commands/compile_commands.json and run clang-tidy with that.
